### PR TITLE
Fix function signature syntax highlighting

### DIFF
--- a/ballerina-mode.el
+++ b/ballerina-mode.el
@@ -86,8 +86,9 @@
     "while")  "All keywords in the ballerina language.  Used for font locking.")
 
 (defconst ballerina-identifier-regexp "[[:word:][:multibyte:]]+")
+(defconst ballerina-type-regexp "[[:word:][:multibyte:]|&?]+")
 (defconst ballerina-func-regexp (concat "\\_<function\\_>\\s *\\(" ballerina-identifier-regexp "\\)"))
-(defconst ballerina-return-type-regexp (concat "\\_<returns\\_>\\s *\\(" ballerina-identifier-regexp "\\)"))
+(defconst ballerina-return-type-regexp (concat "\\_<returns\\_>\\s *\\(" ballerina-type-regexp "\\)"))
 
 (defvar ballerina-mode-syntax-table
   (let ((table (make-syntax-table)))

--- a/ballerina-mode.el
+++ b/ballerina-mode.el
@@ -89,6 +89,9 @@
 (defconst ballerina-type-regexp "[[:word:][:multibyte:]|&?]+")
 (defconst ballerina-func-regexp (concat "\\_<function\\_>\\s *\\(" ballerina-identifier-regexp "\\)"))
 (defconst ballerina-return-type-regexp (concat "\\_<returns\\_>\\s *\\(" ballerina-type-regexp "\\)"))
+(defconst ballerina-var-type-regexp (concat "\\(" ballerina-type-regexp "\\)"
+                                            "[[:space:]][[:space:]]*"
+                                            "\\(" ballerina-identifier-regexp"\\)"))
 
 (defvar ballerina-mode-syntax-table
   (let ((table (make-syntax-table)))
@@ -121,7 +124,9 @@
    `((, (concat "\\_<" (regexp-opt ballerina-mode-basic-types t) "\\_>") . font-lock-type-face)
      (, (concat "\\_<" (regexp-opt ballerina-mode-keywords t) "\\_>") . font-lock-keyword-face)
      (, ballerina-func-regexp 1 font-lock-function-name-face)
-     (, ballerina-return-type-regexp 1 font-lock-type-face))))
+     (, ballerina-return-type-regexp 1 font-lock-type-face)
+     (, ballerina-var-type-regexp 1 font-lock-type-face)
+     (, ballerina-var-type-regexp 2 font-lock-variable-name-face))))
 
 ;;;###autoload
 (define-derived-mode ballerina-mode prog-mode "Ballerina"

--- a/corpus/helloWorld.bal
+++ b/corpus/helloWorld.bal
@@ -14,6 +14,7 @@ public function main() {
 function foo(int a, int b) returns int {
     int c = a * b; // ldalta
     int d = a / b;
+    R a = {};
     return c + a + b;
 }
 
@@ -21,6 +22,6 @@ function bar(int a, string foo) returns R|error {
     return { a, foo };
 }
 
-function baz(int a, string foo) returns R? {
-    return { a, foo };
+function baz(R a, string foo) returns R? {
+    return { ...a, foo };
 }

--- a/corpus/helloWorld.bal
+++ b/corpus/helloWorld.bal
@@ -20,3 +20,7 @@ function foo(int a, int b) returns int {
 function bar(int a, string foo) returns R|error {
     return { a, foo };
 }
+
+function baz(int a, string foo) returns R? {
+    return { a, foo };
+}


### PR DESCRIPTION
Use a nice trick I found in zig-mode [[ref](https://github.com/ziglang/zig-mode/blob/079149a19fc869343130e69d7b944afd3a1813cc/zig-mode.el#L148)] to match `type_name variable_name` pairs